### PR TITLE
Update rules & dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    # Look for `composer.json` and `composer.lock` files in the root directory
+    directory: "/"
+    # Check for updates weekly
+    schedule:
+      interval: "weekly"
+    allow:
+      # Allow direct updates only (for packages named in composer.json)
+      - dependency-type: "direct"
+    # Allow up to 10 open pull requests for composer dependencies
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     # Check for updates weekly
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       # Allow direct updates only (for packages named in composer.json)
       - dependency-type: "direct"

--- a/Pressbooks/ruleset.xml
+++ b/Pressbooks/ruleset.xml
@@ -17,8 +17,8 @@
         <exclude name="WordPress.Security.NonceVerification"/>
         <!-- Disable rules Pressbooks disagrees with: -->
         <exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
-        <exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase"/>
-        <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar"/>
+        <exclude name="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase"/>
+        <exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"/>
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec"/>
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set"/>
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv"/>

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,9 @@
     "type": "project",
     "license": "GPL-3.0-or-later",
     "require": {
-        "humanmade/coding-standards": "^1.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "humanmade/coding-standards": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.5"
     }
 }


### PR DESCRIPTION
This PR changes the names of two excluded rules whose names changed in a previous release of WP coding standards: https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md#changed-5

It also removes squizlabs/php_codesniffer as a direct dependency (it is required by humanmade/coding-standards).

Finally, it adds a dependabot configuration file to automatically check for updates & open relevant PRs on a weekly basis.